### PR TITLE
Enhance/sr check

### DIFF
--- a/ReVox.vcxproj
+++ b/ReVox.vcxproj
@@ -14,13 +14,13 @@
     <ProjectGuid>{2BD12BC2-3306-3A55-9D89-753F9F56FC12}</ProjectGuid>
     <RootNamespace>ReVox</RootNamespace>
     <Keyword>QtVS_v304</Keyword>
-    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.22621.0</WindowsTargetPlatformMinVersion>
     <QtMsBuild Condition="'$(QtMsBuild)'=='' or !Exists('$(QtMsBuild)\qt.targets')">$(MSBuildProjectDirectory)\QtMsBuild</QtMsBuild>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <OutputDirectory>release\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>
@@ -29,7 +29,7 @@
     <PrimaryOutput>ReVox</PrimaryOutput>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <OutputDirectory>debug\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
     <CharacterSet>NotSet</CharacterSet>

--- a/backend/streams/callbacks.h
+++ b/backend/streams/callbacks.h
@@ -35,7 +35,7 @@ typedef struct {
   std::vector<SNDFILE*>* queue;
   SF_INFO info;
   float maxFileLength;
-  std::queue<float>* bufQueue;
+  std::queue<float>* bufQueue;   
 } playData;
 
 typedef struct {
@@ -46,7 +46,7 @@ typedef struct {
   std::unordered_map<std::string, std::shared_ptr<IAudioFX>>* fxs;
 } passthroughData;
 
-typedef struct {
+typedef struct { 
   float monitorMic;
   float monitorSamples;
   std::queue<float>* inputQueue;

--- a/interface/maininterface.cpp
+++ b/interface/maininterface.cpp
@@ -158,6 +158,20 @@ void MainInterface::GetDeviceSettings() {
   if (ids.input == -1) ids.input = Pa_GetDefaultInputDevice();
   if (ids.streamOut == -1) ids.streamOut = Pa_GetDefaultOutputDevice();
   if (ids.output == -1) ids.output = Pa_GetDefaultOutputDevice();
+
+  if (Pa_GetDeviceInfo(ids.vInput)->defaultSampleRate != 48000) {
+      MessageBox(NULL, L"Sample rate of VB-Audio Cable Input is not set to 48000Hz.", L"Error", MB_ICONERROR | MB_OK);
+      log(CRITICAL, "Sample rate of VB-Audio Cable Input is not set to 48000Hz. Exitting.");
+      exit(1);
+      return;
+  }
+
+  if (Pa_GetDeviceInfo(ids.vOutput)->defaultSampleRate != 48000) {
+      log(WARN, "Sample rate of VB-Audio Cable Output is not set to 48000Hz.");
+      MessageBox(NULL, L"Sample rate of VB-Audio Cable Output is not set to 48000Hz and may result in unexpected behaviour.", L"Warning", MB_ICONWARNING | MB_OK);
+  }
+
+
   log(INFO, "Device settings retrieved");
   log(INFO, "Input Device: " + std::string(Pa_GetDeviceInfo(ids.input)->name));
   log(INFO, "Stream Output Device: " + std::string(Pa_GetDeviceInfo(ids.streamOut)->name));

--- a/interface/maininterface.cpp
+++ b/interface/maininterface.cpp
@@ -161,14 +161,14 @@ void MainInterface::GetDeviceSettings() {
 
   if (Pa_GetDeviceInfo(ids.vInput)->defaultSampleRate != 48000) {
       MessageBox(NULL, L"Sample rate of VB-Audio Cable Input is not set to 48000Hz.", L"Error", MB_ICONERROR | MB_OK);
-      log(CRITICAL, "Sample rate of VB-Audio Cable Input is not set to 48000Hz. Exitting.");
+      log(CRITICAL, "Sample rate of VB-Audio Cable Input is not set to 48000Hz. Exiting.");
       exit(1);
       return;
   }
 
   if (Pa_GetDeviceInfo(ids.input)->defaultSampleRate != 48000) {
       MessageBox(NULL, L"Sample rate of default input device is not set to 48000Hz.", L"Error", MB_ICONERROR | MB_OK);
-      log(CRITICAL, "Sample rate of default input device is not set to 48000Hz. Exitting.");
+      log(CRITICAL, "Sample rate of default input device is not set to 48000Hz. Exiting.");
       exit(1);
       return;
   }

--- a/interface/maininterface.cpp
+++ b/interface/maininterface.cpp
@@ -166,8 +166,15 @@ void MainInterface::GetDeviceSettings() {
       return;
   }
 
+  if (Pa_GetDeviceInfo(ids.input)->defaultSampleRate != 48000) {
+      MessageBox(NULL, L"Sample rate of default input device is not set to 48000Hz.", L"Error", MB_ICONERROR | MB_OK);
+      log(CRITICAL, "Sample rate of default input device is not set to 48000Hz. Exitting.");
+      exit(1);
+      return;
+  }
+
   if (Pa_GetDeviceInfo(ids.vOutput)->defaultSampleRate != 48000) {
-      log(WARN, "Sample rate of VB-Audio Cable Output is not set to 48000Hz.");
+      log(WARN, "Sample rate of VB-Audio Cable Input is not set to 48000Hz.");
       MessageBox(NULL, L"Sample rate of VB-Audio Cable Output is not set to 48000Hz and may result in unexpected behaviour.", L"Warning", MB_ICONWARNING | MB_OK);
   }
 

--- a/interface/maininterface.cpp
+++ b/interface/maininterface.cpp
@@ -19,7 +19,7 @@ MainInterface::MainInterface()
     }
 
     dataPath = "settings.json";
-    if (!std::filesystem::exists(rootDir))
+    if (!std::filesystem::exists(rootDir + "samples"))
       std::filesystem::create_directories(rootDir + "samples");
     LoadSettings();
     log(INFO, "Settings loaded");
@@ -159,6 +159,9 @@ void MainInterface::GetDeviceSettings() {
   if (ids.streamOut == -1) ids.streamOut = Pa_GetDefaultOutputDevice();
   if (ids.output == -1) ids.output = Pa_GetDefaultOutputDevice();
   log(INFO, "Device settings retrieved");
+  log(INFO, "Input Device: " + std::string(Pa_GetDeviceInfo(ids.input)->name));
+  log(INFO, "Stream Output Device: " + std::string(Pa_GetDeviceInfo(ids.streamOut)->name));
+  log(INFO, "Output Device: " + std::string(Pa_GetDeviceInfo(ids.output)->name));
 }
 
 int MainInterface::GetChannels(int id, bool isInput) {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -17,6 +17,12 @@ MainWindow::MainWindow(QWidget* parent)
   for (auto const& device : devices->audioInputs()) {
     if (device.description().contains("VB-Audio Virtual Cable")) {
       vCablesFound = true;
+      /*if (device.preferredFormat().sampleRate() != 48000) {
+          QMessageBox::critical(nullptr, "Error", "The sample rate of VB-Cable Output is not set to 48000Hz");
+          //log(CRITICAL, "The sample rate of VB-Cable Output is not set to 48000Hz, stopping");
+          //QApplication::quit();
+          return;
+      }*/
       break;
     }
   }

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -17,12 +17,6 @@ MainWindow::MainWindow(QWidget* parent)
   for (auto const& device : devices->audioInputs()) {
     if (device.description().contains("VB-Audio Virtual Cable")) {
       vCablesFound = true;
-      /*if (device.preferredFormat().sampleRate() != 48000) {
-          QMessageBox::critical(nullptr, "Error", "The sample rate of VB-Cable Output is not set to 48000Hz");
-          //log(CRITICAL, "The sample rate of VB-Cable Output is not set to 48000Hz, stopping");
-          //QApplication::quit();
-          return;
-      }*/
       break;
     }
   }

--- a/ui/menus/settingsmenu.cpp
+++ b/ui/menus/settingsmenu.cpp
@@ -106,7 +106,7 @@ void SettingsMenu::populateDevices() {
   ui->devices->blockSignals(true);
   ui->devices->clear();
   for (auto const &[name, device] : devices) {
-    if (name.find("VB-Audio") != std::string::npos) continue;
+    if (name.find("VB-Audio") != std::string::npos || Pa_GetDeviceInfo(device.id)->defaultSampleRate != 48000) continue;
     ui->devices->addItem(QString::fromStdString(name));
     if (device.id == currentDevice) {
       ui->devices->setCurrentIndex(ui->devices->count() - 1);


### PR DESCRIPTION
Having system sample rate set incorrectly was causing unidentified crashes. This PR notifies the user when an incorrect SR is detected, and handles it accordingly (either exiting or providing a warning popup).